### PR TITLE
Fix runtime speed

### DIFF
--- a/warprnnt_numba/package_info.py
+++ b/warprnnt_numba/package_info.py
@@ -1,5 +1,5 @@
 MAJOR = 0
-MINOR = 3
+MINOR = 4
 PATCH = 0
 PRE_RELEASE = ''
 

--- a/warprnnt_numba/rnnt_loss/rnnt.py
+++ b/warprnnt_numba/rnnt_loss/rnnt.py
@@ -191,9 +191,6 @@ def rnnt_loss_gpu(
     ### VIEW TENSORS AS VECTORS FOR POINTER INDEXING ###
     acts, acts_shape = rnnt_helper.flatten_tensor(acts)
 
-    ### REPRESENT THE CUDA ARRAY INTERFACE OF COSTS VECTOR ###
-    costs_repr = cuda.as_cuda_array(costs, sync=False)  # NO COPY OF DATA, JUST CHANGE REPRESENTATION
-
     wrapper = gpu_rnnt.GPURNNT(
         minibatch=minibatch_size,
         maxT=maxT,
@@ -210,7 +207,7 @@ def rnnt_loss_gpu(
     if grads is None:
         status = wrapper.score_forward(
             acts=acts.data,
-            costs=costs_repr,
+            costs=costs.data,
             pad_labels=labels.data,
             label_lengths=label_lengths.data,
             input_lengths=input_lengths.data,
@@ -226,14 +223,14 @@ def rnnt_loss_gpu(
         status = wrapper.cost_and_grad(
             acts=acts.data,
             grads=grads.data,
-            costs=costs_repr,
+            costs=costs.data,
             pad_labels=labels.data,
             label_lengths=label_lengths.data,
             input_lengths=input_lengths.data,
         )
 
-        if status != global_constants.RNNTStatus.RNNT_STATUS_SUCCESS:
-            raise RuntimeError("Could not calculate forward scores")
+    if status != global_constants.RNNTStatus.RNNT_STATUS_SUCCESS:
+        raise RuntimeError("Could not calculate forward scores")
 
     del gpu_workspace, wrapper
     return True

--- a/warprnnt_numba/rnnt_loss/rnnt.py
+++ b/warprnnt_numba/rnnt_loss/rnnt.py
@@ -229,8 +229,8 @@ def rnnt_loss_gpu(
             input_lengths=input_lengths.data,
         )
 
-    if status != global_constants.RNNTStatus.RNNT_STATUS_SUCCESS:
-        raise RuntimeError("Could not calculate forward scores")
+        if status != global_constants.RNNTStatus.RNNT_STATUS_SUCCESS:
+            raise RuntimeError("Could not calculate forward scores")
 
     del gpu_workspace, wrapper
     return True

--- a/warprnnt_numba/rnnt_loss/rnnt_atomic_locks/rnnt_atomic_locks.py
+++ b/warprnnt_numba/rnnt_loss/rnnt_atomic_locks/rnnt_atomic_locks.py
@@ -92,9 +92,6 @@ def rnnt_loss_gpu(
     ### VIEW TENSORS AS VECTORS FOR POINTER INDEXING ###
     acts, acts_shape = rnnt_helper.flatten_tensor(acts)
 
-    ### REPRESENT THE CUDA ARRAY INTERFACE OF COSTS VECTOR ###
-    costs_repr = cuda.as_cuda_array(costs, sync=False)  # NO COPY OF DATA, JUST CHANGE REPRESENTATION
-
     wrapper = naive_gpu_rnnt.GPURNNTAtomicLocks(
         minibatch=minibatch_size,
         maxT=maxT,
@@ -111,7 +108,7 @@ def rnnt_loss_gpu(
     if grads is None:
         status = wrapper.score_forward(
             acts=acts.data,
-            costs=costs_repr,
+            costs=costs.data,
             pad_labels=labels.data,
             label_lengths=label_lengths.data,
             input_lengths=input_lengths.data,
@@ -127,7 +124,7 @@ def rnnt_loss_gpu(
         status = wrapper.cost_and_grad(
             acts=acts.data,
             grads=grads.data,
-            costs=costs_repr,
+            costs=costs.data,
             pad_labels=labels.data,
             label_lengths=label_lengths.data,
             input_lengths=input_lengths.data,

--- a/warprnnt_numba/rnnt_loss/rnnt_atomic_locks/utils/naive_gpu_rnnt.py
+++ b/warprnnt_numba/rnnt_loss/rnnt_atomic_locks/utils/naive_gpu_rnnt.py
@@ -30,7 +30,7 @@ from typing import Optional
 
 import torch
 
-from warprnnt_numba.rnnt_loss.utils import global_constants
+from warprnnt_numba.rnnt_loss.utils import global_constants, rnnt_helper
 from warprnnt_numba.rnnt_loss.utils.cuda_utils import gpu_rnnt_kernel, gpu_rnnt
 from warprnnt_numba.rnnt_loss.rnnt_atomic_locks.utils import naive_gpu_rnnt_kernel
 
@@ -180,14 +180,19 @@ class GPURNNTAtomicLocks(gpu_rnnt.GPURNNT):
                 self.clamp_,
             )
 
-        # // cost
-        costs.copy_to_device(llForward, stream=self.stream_)
+        # // cost copy, negate (for log likelihood) and update with additional regularizers
+        # This needs to be done via CUDA, because we used temporary memory llForward
+        # passed to alpha, which was updated with log likelihoods.
+        # But copying this data into a pytorch pointer is more difficult (numba api is one way)
+        # Therefore launch a pointwise CUDA kernel to update the costs inplace from data of llForward
+        # Then negate to compute the loglikelihood.
+        threadsperblock = min(costs.shape[0], 128, global_constants.threads_per_block())
+        blockspergrid = (costs.shape[0] + (threadsperblock - 1)) // threadsperblock
+        rnnt_helper.compute_costs_data[blockspergrid, threadsperblock, self.stream_, 0](
+            llForward,
+            costs,
+            self.fastemit_lambda_
+        )
         self.stream_.synchronize()
-
-        # compute negative log likelihood.
-        for mb in range(self.minibatch_):
-            # Scale llForward by FastEmit lambda
-            costs[mb] = -costs[mb]
-            costs[mb] = (1.0 + self.fastemit_lambda_) * costs[mb]
 
         return global_constants.RNNTStatus.RNNT_STATUS_SUCCESS

--- a/warprnnt_numba/rnnt_loss/utils/rnnt_helper.py
+++ b/warprnnt_numba/rnnt_loss/utils/rnnt_helper.py
@@ -97,6 +97,24 @@ def log_plus(p1: float, p2: float):
     return result
 
 
+@cuda.jit(device=True, inline=True)
+def copy_data_1d(source: torch.Tensor, dest: torch.Tensor, idx: int):
+    dest[idx] = source[idx]
+
+
+@cuda.jit()
+def compute_costs_data(source: torch.Tensor, dest: torch.Tensor, fastemit_lambda: float):
+    block = cuda.blockIdx.x
+    tid = cuda.threadIdx.x
+    idx = block * cuda.gridDim.x + tid
+    length = source.shape[0]
+
+    if idx < length:
+        copy_data_1d(source, dest, idx)
+        dest[idx] *= -1.0
+        dest[idx] *= (1.0 + fastemit_lambda)
+
+
 def get_workspace_size(
     maxT: int, maxU: int, minibatch: int, gpu: bool
 ) -> (Optional[int], global_constants.RNNTStatus):


### PR DESCRIPTION
# Improve runtime speed of numba loss 
- Fix issue with data movement of costs tensor from llForward to pytorch data view in numba
- This alone costs a linear loop (scaling with batch size) that is roughly 10x the kernel costs themselves.
- Fix by writing a small kernel to copy the data and update the costs.